### PR TITLE
Localize tank tag labels

### DIFF
--- a/english.json
+++ b/english.json
@@ -29,6 +29,32 @@
     "alertInternalError": "Internal error at question {i}",
     "alertMissing": "Please answer all questions. Missing: {i}"
   },
+  "tags": {
+    "alpha_high": "High alpha",
+    "alpha_med": "Medium alpha",
+    "alpha_veryhigh": "Very high alpha",
+    "armor_high": "Strong armor",
+    "armor_med": "Moderate armor",
+    "arty": "Artillery",
+    "burst": "Burst damage",
+    "control": "Control",
+    "flex": "Flexible",
+    "frontline": "Frontline",
+    "glass": "Very fragile",
+    "glass_light": "Lightly armored",
+    "indirect": "Indirect",
+    "med_heavy": "Medium-heavy mix",
+    "mobility_high": "High mobility",
+    "mobility_low": "Low mobility",
+    "mobility_med": "Average mobility",
+    "mobility_verylow": "Very low mobility",
+    "sniper": "Sniper",
+    "stationary": "Stationary",
+    "superheavy": "Super-heavy",
+    "sustained": "Sustained DPM",
+    "turret_strong": "Strong turret",
+    "vision": "Vision"
+  },
   "sections": {
     "A. Pace & Comfort": [
       "Do you feel more comfortable when battles start slowly?",

--- a/german.json
+++ b/german.json
@@ -29,6 +29,32 @@
     "alertInternalError": "Interner Fehler bei Frage {i}",
     "alertMissing": "Bitte beantworte alle Fragen. Fehlend: {i}"
   },
+  "tags": {
+    "alpha_high": "Hohe Alpha",
+    "alpha_med": "Mittlere Alpha",
+    "alpha_veryhigh": "Sehr hohe Alpha",
+    "armor_high": "Starke Panzerung",
+    "armor_med": "Mittlere Panzerung",
+    "arty": "Artillerie",
+    "burst": "Burst-Schaden",
+    "control": "Kontrolle",
+    "flex": "Flexibel",
+    "frontline": "Frontnah",
+    "glass": "Sehr fragil",
+    "glass_light": "Leicht gepanzert",
+    "indirect": "Indirekt",
+    "med_heavy": "Medium-Schwer-Mix",
+    "mobility_high": "Hohe Mobilität",
+    "mobility_low": "Geringe Mobilität",
+    "mobility_med": "Mittlere Mobilität",
+    "mobility_verylow": "Sehr geringe Mobilität",
+    "sniper": "Sniper",
+    "stationary": "Stationär",
+    "superheavy": "Super-schwer",
+    "sustained": "Konstante DPM",
+    "turret_strong": "Starker Turm",
+    "vision": "Sicht"
+  },
   "sections": {
     "A. Tempo & Komfort": [
       "Fühlst du dich wohler, wenn Gefechte langsam beginnen?",

--- a/index.html
+++ b/index.html
@@ -735,11 +735,13 @@
             const div=document.createElement('div');div.className='recommendation';
             const roleLabel=(I18N&&I18N.ui&&I18N.ui.roleLabel)||'Role';
             const tagsLabel=(I18N&&I18N.ui&&I18N.ui.tagsLabel)||'Tags';
+            const tagMap = I18N && I18N.tags;
+            const tagNames = t.tags.map(k => (tagMap && tagMap[k]) || k).join(', ');
             div.innerHTML=`
         <div class="rec-title">${t.name} (${t.nation}, ${t.cls})</div>
         <div class="muted">${roleLabel}: ${t.role}</div>
         <ul class="bullets">${t.bullets.map(b=>`<li>${b}</li>`).join('')}</ul>
-        <div class="tag muted">${tagsLabel}: ${t.tags.join(', ')}</div>
+        <div class="tag muted">${tagsLabel}: ${tagNames}</div>
       `;
             box.appendChild(div);
         });


### PR DESCRIPTION
## Summary
- add localized tags mapping in translation JSON files
- render tank tags using translation mapping

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('english.json'));console.log('english ok');JSON.parse(require('fs').readFileSync('german.json'));console.log('german ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68b86f35dd588333a155c15bda23e2ce