### PR TITLE
Balance recommendation bias and add recon questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # World of Tanks Tier 10 Quiz
 
-Interactive single-page questionnaire that suggests fitting tier‑10 tanks based on 40 yes/no questions.
+Interactive single-page questionnaire that suggests fitting tier‑10 tanks based on 46 yes/no questions.

--- a/english.json
+++ b/english.json
@@ -3,7 +3,7 @@
     "pageTitle": "WoT – Neutral Questionnaire & Recommendation",
     "headerTitle": "World of Tanks – Neutral Questionnaire & Tier 10 Recommendation",
     "classesPill": "Classes considered: Light · Medium · Heavy · TD · SPG",
-    "introText": "Answer 40 neutral yes/no questions. At the end you'll receive 2–3 suitable tier 10 suggestions (across classes), brief playstyle notes and a section “Why not other classes?”.",
+    "introText": "Answer 46 neutral yes/no questions. At the end you'll receive 2–3 suitable tier 10 suggestions (across classes), brief playstyle notes and a section “Why not other classes?”.",
     "btnStart": "Start questionnaire",
     "btnDemo": "Load sample answers",
     "btnReset": "Reset",
@@ -105,10 +105,18 @@
       "Is it more important to you to be extremely strong in a clear niche rather than just ok everywhere?",
       "Would you prefer a tank that works well solo regardless of team?",
       "Would you be satisfied doing little alone if you are indispensable with a team?"
+    ],
+    "F. Support & Recon": [
+      "Do you enjoy spotting enemies for your team even if you do not damage them?",
+      "Is providing support fire from a distance appealing to you?",
+      "Do you like helping teammates by stunning or tracking opponents?",
+      "Would you prefer staying hidden over trading blows directly?",
+      "Is coordinating with allies to maximize their damage satisfying to you?",
+      "Does indirect contribution, such as assist damage, interest you more than raw damage?"
     ]
   },
   "tanks": [
-    { "id":"is7","name":"IS-7","nation":"USSR","cls":"Heavy","role":"durable frontline heavy, forgiving and mobile enough","bullets":["Sidescrape and trade with 490 alpha","Can push or hold positions","Solid all-rounder for gun marks"],"tags":["armor_high","alpha_med","mobility_med","sustained","frontline","flex"] },
+{ "id":"is7","name":"IS-7","nation":"USSR","cls":"Heavy","role":"durable frontline heavy, forgiving and mobile enough","bullets":["Sidescrape and trade with 490 alpha","Can push or hold positions","Solid all-rounder for gun marks"],"tags":["armor_high","alpha_med","mobility_med","frontline"] },
     { "id":"is4","name":"IS-4","nation":"USSR","cls":"Heavy","role":"classic armor-blocking heavy","bullets":["Sidescrape and play methodically","Trade consistently","Tough but slow"],"tags":["armor_high","sustained","mobility_low","frontline"] },
     { "id":"obj277","name":"Object 277","nation":"USSR","cls":"Heavy","role":"fast alpha-trading heavy","bullets":["Aggressive openings","490 alpha with mobility","Less forgiving of mistakes"],"tags":["alpha_med","mobility_high","flex"] },
     { "id":"obj705a","name":"Object 705A","nation":"USSR","cls":"Heavy","role":"side-scraping brawler with high alpha","bullets":["Close-range trading","Strong sides for angling","Works in corridors"],"tags":["alpha_high","armor_high","mobility_low","frontline"] },

--- a/german.json
+++ b/german.json
@@ -3,7 +3,7 @@
     "pageTitle": "WoT – Neutrales Fragenmodul & Empfehlung",
     "headerTitle": "World of Tanks – Neutrales Fragenmodul & Tier‑10‑Empfehlung",
     "classesPill": "Berücksichtigte Klassen: Leicht · Mittel · Schwer · Jagdpanzer · Artillerie",
-    "introText": "Beantworte 40 neutrale Ja/Nein‑Fragen. Am Ende erhältst du 2–3 passende Tier‑10‑Vorschläge (klassenübergreifend), kurze Spielstil‑Hinweise und einen Abschnitt „Warum nicht andere Klassen?“. ",
+    "introText": "Beantworte 46 neutrale Ja/Nein‑Fragen. Am Ende erhältst du 2–3 passende Tier‑10‑Vorschläge (klassenübergreifend), kurze Spielstil‑Hinweise und einen Abschnitt „Warum nicht andere Klassen?“. ",
     "btnStart": "Fragebogen starten",
     "btnDemo": "Beispielantworten laden",
     "btnReset": "Zurücksetzen",
@@ -105,10 +105,18 @@
       "Ist es dir wichtiger, in einer klaren Nische extrem stark zu sein, statt überall nur okay?",
       "Würdest du einen Panzer bevorzugen, der solo gut funktioniert – unabhängig vom Team?",
       "Wärst du zufrieden, alleine wenig zu machen, wenn du im Team unentbehrlich bist?"
+    ],
+    "F. Unterstützung & Aufklärung": [
+      "Macht es dir Spaß, Gegner für dein Team aufzuklären, auch wenn du sie nicht selbst beschädigst?",
+      "Findest du Unterstützungsfeuer aus der Distanz reizvoll?",
+      "Hilfst du gern Teamkameraden, indem du Gegner betäubst oder kettest?",
+      "Bleibst du lieber verborgen, statt direkt Schüsse zu tauschen?",
+      "Empfindest du es als befriedigend, mit Verbündeten zu koordinieren, um deren Schaden zu maximieren?",
+      "Interessiert dich indirekter Beitrag, z. B. Assistenzschaden, mehr als direkter Schaden?"
     ]
   },
   "tanks": [
-    { "id":"is7","name":"IS-7","nation":"UdSSR","cls":"Schwer","role":"robuster Frontlinien‑Schwerer, verzeihend und ausreichend mobil","bullets":["Seitlich anwinkeln und mit 490 Alpha traden","Kann Positionen drücken oder halten","Solider Allrounder fürs Markieren"],"tags":["armor_high","alpha_med","mobility_med","sustained","frontline","flex"] },
+{ "id":"is7","name":"IS-7","nation":"UdSSR","cls":"Schwer","role":"robuster Frontlinien‑Schwerer, verzeihend und ausreichend mobil","bullets":["Seitlich anwinkeln und mit 490 Alpha traden","Kann Positionen drücken oder halten","Solider Allrounder fürs Markieren"],"tags":["armor_high","alpha_med","mobility_med","frontline"] },
     { "id":"is4","name":"IS-4","nation":"UdSSR","cls":"Schwer","role":"klassischer Riegel‑Schwerer","bullets":["Seitlich anwinkeln und methodisch spielen","Konstant traden","Zäh, aber langsam"],"tags":["armor_high","sustained","mobility_low","frontline"] },
     { "id":"obj277","name":"Object 277","nation":"UdSSR","cls":"Schwer","role":"schneller Alpha‑Trader","bullets":["Aggressive Eröffnungen","490 Alpha mit Mobilität","Weniger verzeihend bei Fehlern"],"tags":["alpha_med","mobility_high","flex"] },
     { "id":"obj705a","name":"Object 705A","nation":"UdSSR","cls":"Schwer","role":"Seiten‑Scraper‑Brawler mit hohem Alpha","bullets":["Nahkampf‑Trading","Starke Seiten zum Anwinkeln","Funktioniert in Korridoren"],"tags":["alpha_high","armor_high","mobility_low","frontline"] },

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     </header>
 
     <div class="card" id="intro">
-        <p class="muted" id="introText">Answer 40 neutral yes/no questions. At the end you'll receive 2–3 suitable tier 10 suggestions (across classes), brief playstyle notes and a section “Why not other classes?”.</p>
+        <p class="muted" id="introText">Answer 46 neutral yes/no questions. At the end you'll receive 2–3 suitable tier 10 suggestions (across classes), brief playstyle notes and a section “Why not other classes?”.</p>
         <div class="actions">
             <button class="primary" id="btnStart" onclick="start()">Start questionnaire</button>
             <button id="btnDemo" onclick="demoFill()">Load sample answers</button>
@@ -127,6 +127,14 @@
             'Is it more important to you to be extremely strong in a clear niche rather than just ok everywhere?',
             'Would you prefer a tank that works well solo regardless of team?',
             'Would you be satisfied doing little alone if you are indispensable with a team?'
+        ],
+        'F. Support & Recon': [
+            'Do you enjoy spotting enemies for your team even if you do not damage them?',
+            'Is providing support fire from a distance appealing to you?',
+            'Do you like helping teammates by stunning or tracking opponents?',
+            'Would you prefer staying hidden over trading blows directly?',
+            'Is coordinating with allies to maximize their damage satisfying to you?',
+            'Does indirect contribution, such as assist damage, interest you more than raw damage?'
         ]
     };
     const TANKS = [
@@ -134,7 +142,7 @@
         { id:'is7', name:'IS-7', nation:'USSR', cls:'Heavy',
             role:'durable frontline heavy, forgiving and mobile enough',
             bullets:['Sidescrape and trade with 490 alpha','Can push or hold positions','Solid all-rounder for gun marks'],
-            tags:['armor_high','alpha_med','mobility_med','sustained','frontline','flex'] },
+            tags:['armor_high','alpha_med','mobility_med','frontline'] },
         { id:'is4', name:'IS-4', nation:'USSR', cls:'Heavy',
             role:'classic armor-blocking heavy',
             bullets:['Sidescrape and play methodically','Trade consistently','Tough but slow'],
@@ -482,6 +490,22 @@
         if(a(38)) pref.flexibility+=0; else pref.sustained+=1;
         if(a(39)) pref.flexibility+=2; else pref.indirect+=1;
         if(a(40)) pref.indirect+=2; else pref.presence+=1;
+        if(a(41)) pref.vision+=2;
+        if(a(42)) pref.indirect+=2;
+        if(a(43)) pref.indirect+=1;
+        if(a(44)) {pref.vision+=1;} else {pref.presence+=1;}
+        if(a(45)) pref.indirect+=1;
+        if(a(46)) pref.indirect+=1; else pref.alpha+=1;
+        // neutralize inherent positive bias
+        pref.mobility-=0.5;
+        pref.sustained-=8.5;
+        pref.burst-=1.5;
+        pref.presence-=5.5;
+        pref.indirect-=7;
+        pref.armor-=2;
+        pref.alpha-=2.5;
+        pref.vision-=2.5;
+        pref.flexibility-=4.5;
         function scoreTank(t){
             let s=0; const tags=t.tags||[];
             if(tags.includes('mobility_high')) s+=pref.mobility>1?2:0;


### PR DESCRIPTION
## Summary
- Add new "Support & Recon" section with six questions to cover spotting and indirect fire
- Normalize preference scores to remove heavy-class bias and retune tags (IS-7 loses sustained/flex)
- Update translations and documentation for 46-question flow

## Testing
- `node - <<'NODE'
const en=require('./english.json');
const de=require('./german.json');
function totals(obj){return Object.values(obj.sections).reduce((s,a)=>s+a.length,0);}
console.log('EN sections',Object.values(en.sections).map(a=>a.length));
console.log('DE sections',Object.values(de.sections).map(a=>a.length));
console.log('Totals',totals(en),totals(de));
NODE`
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('index.html','utf8');
const script=code.match(/<script>([\s\S]*)<\/script>/)[1];
const context={console, document:{addEventListener(){}}, window:{}};
vm.createContext(context);
vm.runInContext(script, context);
function randAns(){const total=context.getTotalQuestions();const arr=[];for(let i=0;i<total;i++)arr.push(Math.random()<0.5);return arr;}
function simulate(n){const dist={class:{},tank:{}};for(let i=0;i<n;i++){const ans=randAns();const {scored}=context.evaluate(ans);const top=scored[0].t;dist.tank[top.id]=(dist.tank[top.id]||0)+1;dist.class[top.cls]=(dist.class[top.cls]||0)+1;}console.log('Class dist',dist.class);const tops=Object.entries(dist.tank).sort((a,b)=>b[1]-a[1]).slice(0,5);console.log('Top tanks',tops);}
simulate(10000);
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87aab4c5c83338910747aabeedfbe